### PR TITLE
[FIX] issue #11 - create empty states for general informations of hotel

### DIFF
--- a/src/App/CabanasRD/Framework/DataSources/InMemoryMotelsSource.cs
+++ b/src/App/CabanasRD/Framework/DataSources/InMemoryMotelsSource.cs
@@ -162,7 +162,109 @@ namespace CabanasRD.Framework.DataSources
                                 Price = 1350.00
                             }
                         }
+                    },
+                    // Data for testing...
+                    new Motel{
+                        Id = 4,
+                        Latitude = 19.2634426,
+                        Longitude = -70.223765,
+                        Name = "Centro Girasoles",
+                        Images = new List<MotelImage>(),
+                        Phones = new List<MotelPhone>{
+                            new MotelPhone{ Number = "809-000-0000"},
+                            new MotelPhone{ Number = "829-000-0000"},
+                            new MotelPhone{ Number = "849-000-0000"}
+
+                        },
+                        Services = new List<MotelService>{
+                            new MotelService {
+                                Name = "Normal",
+                                Price = 725.00
+                            },
+                            new MotelService {
+                                Name = "Ejecutiva",
+                                Price = 925.00
+                            }
+                        }
+                    },  // No images
+                    new Motel{
+                    Id = 5,
+                    Latitude = 18.81113,
+                    Longitude = -71.2330894,
+                    Name = "Hotel La Gran Posada",
+                    Images = new List<MotelImage>{
+                        new MotelImage {
+                            Url = "https://c2.peakpx.com/wallpaper/604/823/790/castle-fortress-defense-architecture-wallpaper-preview.jpg"
+                        },
+                        new MotelImage {
+                            Url = "https://media.npr.org/assets/img/2015/08/15/robin1-8aea039fd0710bd0c8549c19abab4085e0e3024c-s800-c85.jpg"
+                        },
+                        new MotelImage {
+                            Url = "https://c2.peakpx.com/wallpaper/604/823/790/castle-fortress-defense-architecture-wallpaper-preview.jpg"
+                        },
+                        new MotelImage {
+                            Url = "https://media.npr.org/assets/img/2015/08/15/robin1-8aea039fd0710bd0c8549c19abab4085e0e3024c-s800-c85.jpg"
+                        },
+                        new MotelImage {
+                            Url = "https://c2.peakpx.com/wallpaper/604/823/790/castle-fortress-defense-architecture-wallpaper-preview.jpg"
+                        },
+                        new MotelImage {
+                            Url = "https://media.npr.org/assets/img/2015/08/15/robin1-8aea039fd0710bd0c8549c19abab4085e0e3024c-s800-c85.jpg"
+                        }
+                    },
+                    Phones = new List<MotelPhone>(),
+                    Services = new List<MotelService>{
+                        new MotelService {
+                            Name = "Normal",
+                            Price = 725.00
+                        },
+                        new MotelService {
+                            Name = "Ejecutiva",
+                            Price = 925.00
+                        }
                     }
+                },  // No phones
+                    new Motel{
+                        Id = 6,
+                        Latitude = 19.5869773,
+                        Longitude = -71.0357848,
+                        Name = "Cabañas Bernard",
+                        Images = new List<MotelImage>{
+                            new MotelImage {
+                                Url = "https://c2.peakpx.com/wallpaper/604/823/790/castle-fortress-defense-architecture-wallpaper-preview.jpg"
+                            },
+                            new MotelImage {
+                                Url = "https://media.npr.org/assets/img/2015/08/15/robin1-8aea039fd0710bd0c8549c19abab4085e0e3024c-s800-c85.jpg"
+                            },
+                            new MotelImage {
+                                Url = "https://c2.peakpx.com/wallpaper/604/823/790/castle-fortress-defense-architecture-wallpaper-preview.jpg"
+                            },
+                            new MotelImage {
+                                Url = "https://media.npr.org/assets/img/2015/08/15/robin1-8aea039fd0710bd0c8549c19abab4085e0e3024c-s800-c85.jpg"
+                            },
+                            new MotelImage {
+                                Url = "https://c2.peakpx.com/wallpaper/604/823/790/castle-fortress-defense-architecture-wallpaper-preview.jpg"
+                            },
+                            new MotelImage {
+                                Url = "https://media.npr.org/assets/img/2015/08/15/robin1-8aea039fd0710bd0c8549c19abab4085e0e3024c-s800-c85.jpg"
+                            }
+                        },
+                        Phones = new List<MotelPhone>{
+                            new MotelPhone{ Number = "809-000-0000"},
+                            new MotelPhone{ Number = "829-000-0000"}
+
+                        },
+                        Services = new List<MotelService>()
+                    },  // No services
+                    new Motel{
+                        Id = 4,
+                        Latitude = 18.2064847,
+                        Longitude = -71.09799,
+                        Name = "Hotel Las Magnolias",
+                        Images = new List<MotelImage>(),
+                        Phones = new List<MotelPhone>(),
+                        Services = new List<MotelService>()
+                    },  // No images, phones, services
             };
         }
     }

--- a/src/App/CabanasRD/UI/Map/Converters/CollectionHasElementsConverter.cs
+++ b/src/App/CabanasRD/UI/Map/Converters/CollectionHasElementsConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms;
+
+namespace CabanasRD.UI.Map.Converters
+{
+    class CollectionHasElementsConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (int)value != 0 ? true : false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+}

--- a/src/App/CabanasRD/UI/Map/Views/MotelDetailsPage.xaml
+++ b/src/App/CabanasRD/UI/Map/Views/MotelDetailsPage.xaml
@@ -6,14 +6,22 @@
     xmlns:ffimageloadingsvg="clr-namespace:FFImageLoading.Svg.Forms;assembly=FFImageLoading.Svg.Forms"
     xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
     xmlns:yummy="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
+    xmlns:converters="clr-namespace:CabanasRD.UI.Map.Converters"
     ios:NavigationPage.HideNavigationBarSeparator="true"
     BackgroundColor="#FFFFFF">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:CollectionHasElementsConverter x:Key="CollectionHasElementsConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    
     <ContentPage.Content>
         <ScrollView>
             <Grid RowSpacing="10">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="219" />
-                    <RowDefinition Height="296" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -86,8 +94,10 @@
                 <CarouselView
                     Grid.Row="1"
                     Margin="20,10"
+                    HeightRequest="296"
                     IndicatorView="indicatorView"
-                    ItemsSource="{Binding Images}">
+                    ItemsSource="{Binding Images}"
+                    IsVisible="{Binding Images.Count, Converter={StaticResource CollectionHasElementsConverter}}">
                     <CarouselView.ItemTemplate>
                         <DataTemplate>
                             <yummy:PancakeView
@@ -109,7 +119,8 @@
                     x:Name="indicatorView"
                     Grid.Row="2"
                     IndicatorColor="LightGray"
-                    SelectedIndicatorColor="DarkGray" />
+                    SelectedIndicatorColor="DarkGray"
+                    IsVisible="{Binding Images.Count, Converter={StaticResource CollectionHasElementsConverter}}" />
                 <!--  END OF PICS LAYOUT  -->
                 <!--  SERVICES LAYOUT  -->
                 <yummy:PancakeView
@@ -126,6 +137,29 @@
                             Style="{DynamicResource CardTitle}"
                             Text="Precios" />
                         <StackLayout BindableLayout.ItemsSource="{Binding Services, Mode=OneTime}" HorizontalOptions="Start">
+                            <BindableLayout.EmptyViewTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Label Grid.Column="0"
+                                               Margin="10,0"
+                                               FontSize="Medium"
+                                               HorizontalOptions="Center"
+                                               Style="{DynamicResource CardBoldDetail}"
+                                               Text="Precios de servicios no disponibles."
+                                               TextColor="#FFFFFF"
+                                               VerticalOptions="Center" />
+                                        <yummy:PancakeView Grid.Column="0"
+                                                           BackgroundColor="#000000"
+                                                           CornerRadius="16"
+                                                           HeightRequest="32"
+                                                           Opacity="0.07" />
+                                    </Grid>
+                                </DataTemplate>
+                            </BindableLayout.EmptyViewTemplate>
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate>
                                     <Grid>
@@ -179,6 +213,29 @@
                             Style="{DynamicResource CardTitle}"
                             Text="Teléfonos" />
                         <StackLayout BindableLayout.ItemsSource="{Binding Phones}" HorizontalOptions="Start">
+                            <BindableLayout.EmptyViewTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Label Grid.Column="0"
+                                               Margin="10,0"
+                                               FontSize="Medium"
+                                               HorizontalOptions="Center"
+                                               Style="{DynamicResource CardBoldDetail}"
+                                               Text="Teléfonos no disponibles."
+                                               TextColor="#FFFFFF"
+                                               VerticalOptions="Center" />
+                                        <yummy:PancakeView Grid.Column="0"
+                                                           BackgroundColor="#000000"
+                                                           CornerRadius="16"
+                                                           HeightRequest="32"
+                                                           Opacity="0.07" />
+                                    </Grid>
+                                </DataTemplate>
+                            </BindableLayout.EmptyViewTemplate>
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate>
                                     <Grid>


### PR DESCRIPTION
-CarouselView not visible when the hotel has not images (a converter is needed).
-EmptyViewTemplate when the hotel does not have prices for services or phones.

### Before this change:
* Not images, services and prices, phones
<p aling="center">
<img src="https://user-images.githubusercontent.com/54010882/90973702-93bbd300-e4f2-11ea-9293-1da3b5b3d317.PNG" width="40%" />
</p>
* Not services and prices
<p aling="center">
<img src="https://user-images.githubusercontent.com/54010882/90973703-93bbd300-e4f2-11ea-8b33-e296a00872e3.PNG" width="40%" />
</p>
* Not images
<p aling="center">
<img src="https://user-images.githubusercontent.com/54010882/90973705-94546980-e4f2-11ea-9889-463301a3932e.PNG" width="40%" />
</p>
* Not phones
<p aling="center">
<img src="https://user-images.githubusercontent.com/54010882/90973706-94546980-e4f2-11ea-8b6e-e9fff79d99e7.PNG" width="40%" />
</p>

After this change:
<p aling="center">
<img src="https://user-images.githubusercontent.com/54010882/90973754-fdd47800-e4f2-11ea-83d5-21c440a5216c.PNG" width="45%" />
<img src="https://user-images.githubusercontent.com/54010882/90973755-fe6d0e80-e4f2-11ea-9030-f68c4ec1e295.PNG" width="45%" />
<img src="https://user-images.githubusercontent.com/54010882/90973756-ff05a500-e4f2-11ea-9132-5c166e90b899.PNG" width="45%" />
<img src="https://user-images.githubusercontent.com/54010882/90973757-ff05a500-e4f2-11ea-86df-c1dfda5aaaed.PNG" width="45%" />
</p>
